### PR TITLE
feat(merge_request_hook): allow to disable git commit message check

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,7 @@ The `BOT_GITLAB_MERGE_REQUEST_SUMMARY_LANGUAGE` parameter specifies the language
 **`BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED`**
 
 Merge requests can only be merged if the email username (before the "@") matches the commit author's name. By default, this requirement is disabled.
+
+**`BOT_GIT_COMMIT_MESSAGE_CHECK_ENABLED`**
+
+Merge requests can only be merged if the commit message follows a specific format. When it's set to `true`, the bot will validate commit messages based on a specified regex defined by the `BOT_GIT_COMMIT_SUBJECT_REGEX` environment variable.

--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,7 @@ DEFAULT_BOT_GITLAB_MERGE_REQUEST_ISSUE_REQUIRED_VALUE = "false"
 DEFAULT_BOT_GIT_COMMIT_SUBJECT_REGEX_ENABLED = "true"
 DEFAULT_BOT_GITLAB_MERGE_REQUEST_SUMMARY_ENABLED_VALUE = "true"
 DEFAULT_BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED = "true"
+DEFAULT_BOT_GIT_COMMIT_MESSAGE_CHECK_ENABLED = "true"
 
 # openai api
 openai_api_base = os.getenv("OPENAI_API_BASE")
@@ -64,6 +65,14 @@ bot_gitlab_token = os.getenv("BOT_GITLAB_TOKEN", None)
 bot_git_email_domain = os.getenv("BOT_GIT_EMAIL_DOMAIN", None)
 
 # git commits
+bot_git_commit_message_check_enabled = (
+    os.getenv(
+        "BOT_GIT_COMMIT_MESSAGE_CHECK_ENABLED",
+        DEFAULT_BOT_GIT_COMMIT_MESSAGE_CHECK_ENABLED,
+    ).lower()
+    == "true"
+)
+
 bot_git_commit_subject_regex_enabled = (
     os.getenv(
         "BOT_GIT_COMMIT_SUBJECT_REGEX_ENABLED",

--- a/src/merge_request_hook.py
+++ b/src/merge_request_hook.py
@@ -25,6 +25,7 @@ from src.config import (
     bot_gitlab_merge_request_summary_enabled,
     bot_gitlab_username,
     bot_gitlab_merge_request_email_username_not_match_enabled
+    bot_git_commit_message_check_enabled
 )
 from src.i18n import _
 from src.llm import AI, ai_diffs_summary
@@ -38,6 +39,8 @@ def check_changes(gl, project_id, iid):
 
 
 def check_commit_message(commit_msg):
+    if bot_git_commit_message_check_enabled == False:
+        return
     if len(commit_msg) > bot_git_commit_subject_max_length:
         raise Exception(
             _("commit_subject_max_length").format(


### PR DESCRIPTION
This commit introduces the ability to disable the Git commit message check within the merge request hook. Previously, the tool always performed this check, but now it offers more flexibility.

The main change is the addition of a new environment variable, `BOT_GIT_COMMIT_MESSAGE_CHECK_ENABLED`, which defaults to `true`. This variable lets users control whether the commit message check is enabled or disabled.

The code now checks this variable in the `check_commit_message` function within `merge_request_hook.py`. If the variable is set to `false`, the commit message check is skipped, providing an option to bypass this validation for specific scenarios.

This change allows users to tailor the tool's behavior by enabling or disabling the commit message check based on their specific needs and workflows.