### PR TITLE
feat(merge_request_hook): add AI review status label

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,9 @@ Merge requests can only be merged if the commit message follows a specific forma
 **`BOT_GITLAB_MERGE_REQUEST_APPROVAL_ENABLED`**
 
 This parameter controls whether the bot automatically approves merge requests that pass all checks. By default, it is set to `true`, allowing the bot to automatically approve merge requests. Setting it to `false` disables automatic approval, requiring manual approval for all merge requests.
+
+**`BOT_GITLAB_MERGE_REQUEST_AIREVIEW_LABEL_ENABLED`**
+
+This parameter controls the feature to add a new status label "AI Review" to merge requests, facilitating better tracking of AI-assisted code reviews. When enabled, the label is automatically added when AI summary generation is enabled and completed. The label is removed when a Merge Request is updated but the AI feature is disabled.
+
+By default, this feature is enabled. To disable it, set the `BOT_GITLAB_MERGE_REQUEST_AIREVIEW_LABEL_ENABLED` environment variable to "false". This feature is particularly useful for projects that heavily rely on AI-assisted code reviews to ensure that all code changes are thoroughly examined before merging.

--- a/src/config.py
+++ b/src/config.py
@@ -39,6 +39,7 @@ DEFAULT_BOT_GITLAB_MERGE_REQUEST_SUMMARY_ENABLED_VALUE = "true"
 DEFAULT_BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED = "true"
 DEFAULT_BOT_GITLAB_MERGE_REQUEST_APPROVAL_ENABLED = "true"
 DEFAULT_BOT_GIT_COMMIT_MESSAGE_CHECK_ENABLED = "true"
+DEFAULT_BOT_GITLAB_MERGE_REQUEST_AIREVIEW_LABEL_ENABLED = "true"
 
 # openai api
 openai_api_base = os.getenv("OPENAI_API_BASE")
@@ -136,6 +137,15 @@ bot_gitlab_merge_request_approval_enabled = (
     os.getenv(
         "BOT_GITLAB_MERGE_REQUEST_APPROVAL_ENABLED",
         DEFAULT_BOT_GITLAB_MERGE_REQUEST_APPROVAL_ENABLED,
+    ).lower()
+    == "true"
+)
+
+# gitlab merge request ai review label
+bot_gitlab_merge_request_aireview_label_enabled = (
+    os.getenv(
+        "BOT_GITLAB_MERGE_REQUEST_AIREVIEW_LABEL_ENABLED",
+        DEFAULT_BOT_GITLAB_MERGE_REQUEST_AIREVIEW_LABEL_ENABLED,
     ).lower()
     == "true"
 )


### PR DESCRIPTION
This commit introduces a new "AI Review" status label to merge requests, enhancing the review process by providing a clear indicator that the AI assistant has reviewed and summarized the changes.

The code adds an `StatusLabel` enum to represent the new status label, ensuring consistency and maintainability.  A new function `add_status_label` handles the logic for adding the "AI Review" label to merge requests. This function checks if the label already exists and adds it if necessary, logging the process for debugging. A `is_status_label` function verifies the validity of status labels.

Finally, the `generate_diff_description_summary` function now adds the "AI Review" label to merge requests after generating the summary. This ensures that all changes are thoroughly reviewed by the AI assistant, streamlining the review process.