### PR TITLE
feat(merge_request): skip AI summary generation when no code changes

### DIFF
--- a/src/merge_request_hook.py
+++ b/src/merge_request_hook.py
@@ -107,6 +107,11 @@ async def generate_diff_description_summary(event, gl):
     description = event.data["object_attributes"]["description"]
     labels = event.data["object_attributes"]["labels"]
     iid = event.data["object_attributes"]["iid"]
+    change_event = event.data["changes"]
+    if not change_event:
+        logging.debug(f"MR has no code changes, AI Summary generation skipped...")
+        return None
+            
     if bot_gitlab_merge_request_summary_enabled and AI is not None:
         try:
             if not has_ai_review(description, labels):


### PR DESCRIPTION
This PR is to prevent the AI summary generation for merge requests (MRs) that contain non-code updates, such as changes to the description or labels. This optimization focuses the AI summarization effort on MRs with actual code modifications.

The code now explicitly checks for the presence of "change_event" data within the event payload. If there are no code changes, the function skips the summary generation and logs a debug message. This ensures that the AI resources are used efficiently and prevents unnecessary processing of MRs with only metadata updates.