### PR TITLE
feat: add Azure OpenAI models support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,13 @@ These parameters are used to connect the OPENAI model.
 
 These parameters are used to connect Google models.
 
+**`AZURE_OPENAI_API_KEY` / `AZURE_OPENAI_API_VERSION` / `AZURE_OPENAI_MODEL` / `AZURE_OPENAI_ENDPOINT`**
+
+These parameters are used to connect Azure OpenAI models.
+
 **`AI_PROVIDER`**
 
-This parameter is used to select the backend for the AI model. By default, it is set to `openai`. You can change it to `google` to use Google models.
+This parameter specifies the AI model backend to use. The default value is `openai`, but you can switch to `google` for Google models or `azure-openai` for Azure OpenAI models.
 
 **`BOT_GITLAB_MERGE_REQUEST_SUMMARY_ENABLED` / `BOT_GITLAB_MERGE_REQUEST_SUMMARY_LANGUAGE`**
 

--- a/src/config.py
+++ b/src/config.py
@@ -46,12 +46,24 @@ openai_api_base = os.getenv("OPENAI_API_BASE")
 openai_api_key = os.getenv("OPENAI_API_KEY")
 openai_api_model = os.getenv("OPENAI_API_MODEL")
 
+# azure openai
+azure_openai_api_key = os.getenv("AZURE_OPENAI_API_KEY")
+azure_openai_api_version = os.getenv("AZURE_OPENAI_API_VERSION")
+azure_openai_model = os.getenv("AZURE_OPENAI_MODEL")
+azure_openai_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+
 # google gemini api
 google_api_key = os.getenv("GOOGLE_API_KEY")
 google_api_model = os.getenv("GOOGLE_API_MODEL")
 
 # ai backend (openai or gemini)
 AI_PROVIDER = os.getenv("AI_PROVIDER", "openai")
+
+model_name = {
+    "openai": openai_api_model,
+    "azure-openai": azure_openai_model,
+    "google": google_api_model,
+}.get(AI_PROVIDER, None)
 
 # i18n
 bot_language = os.environ.get("BOT_LANGUAGE", "en")

--- a/src/llm.py
+++ b/src/llm.py
@@ -16,17 +16,28 @@ import json
 import logging
 
 from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
+from langchain_openai import ChatOpenAI, AzureChatOpenAI
 from langchain_google_genai import ChatGoogleGenerativeAI
 
-from src.config import bot_language, openai_api_base, openai_api_key, openai_api_model, google_api_key, google_api_model, AI_PROVIDER
+from src.config import (
+    bot_language,
+    openai_api_base,
+    openai_api_key,
+    google_api_key,
+    azure_openai_api_key,
+    azure_openai_api_version,
+    azure_openai_endpoint,
+    model_name,
+    AI_PROVIDER
+)
+
 from src.i18n import _
 from src.prompts.prompts import get_prompt_text
 
 AI = None
 
 if (
-    openai_api_model is not None
+    model_name is not None
     and openai_api_key is not None
     and openai_api_base is not None
     and AI_PROVIDER == "openai"
@@ -34,7 +45,7 @@ if (
     AI = ChatOpenAI(
         openai_api_base=openai_api_base,
         openai_api_key=openai_api_key,
-        model_name=openai_api_model,
+        model_name=model_name,
         temperature=0,
         request_timeout=300,
         max_retries=2,
@@ -42,11 +53,25 @@ if (
 
 if (
     google_api_key is not None
-    and google_api_model is not None
+    and model_name is not None
     and AI_PROVIDER == "google"
 ):
-    AI = ChatGoogleGenerativeAI(model=google_api_model)
+    AI = ChatGoogleGenerativeAI(model=model_name)
 
+if (
+    azure_openai_api_key is not None
+    and model_name is not None
+    and azure_openai_api_version is not None
+    and azure_openai_endpoint is not None
+    and AI_PROVIDER == "azure-openai"
+):
+    AI = AzureChatOpenAI(
+        azure_deployment=model_name,
+        api_version=azure_openai_api_version,
+        temperature=0,
+        timeout=300,
+        max_retries=2
+    )
 
 def ai_diffs_summary(git_diff) -> str:
     summary_descriptions = []
@@ -71,4 +96,4 @@ def ai_diffs_summary(git_diff) -> str:
         # if isinstance(e, OpenAIError):
         #     summary_description = f"{prefix}\n>{e.json_body['message']}"
     descriptions = "\n".join(summary_descriptions)
-    return f"**{prefix}**\n\n{descriptions}\n\n**{suffix}** {openai_api_model}"
+    return f"**{prefix}**\n\n{descriptions}\n\n**{suffix}** {model_name}"


### PR DESCRIPTION
Adds support for Azure OpenAI models in the diff summarizer. Now, we can specify `azure-openai` in the `AI_PROVIDER` environment variable to utilize Azure OpenAI backend.

The changes include:

* Adding required environment variables (`AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_MODEL`, `AZURE_OPENAI_ENDPOINT`) in the `config.py` file to store Azure OpenAI parameters.
* Fix a "Powered by None" message in the Merge request description summary suffix by adding a `model_name` dictionary in `config.py` to select the name of the AI model to use