### PR TITLE
chore: bump gidgetlab to v2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gidgetlab[aiohttp]>=1.1.0
+gidgetlab[aiohttp]>=2.0.1
 langchain_core==0.2.0
 langchain-openai==0.1.7
 langchain-google-genai==1.0.4 # This package contains the LangChain integrations for the Gemini API.


### PR DESCRIPTION
Bump gidgetlab version from `1.1.0` to `2.0.1`

This change updates the gidgetlab dependency to version `2.0.1` to fix a [HIGH vulnerability](https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&cpe_vendor=cpe%3A%2F%3Aaiohttp&cpe_product=cpe%3A%2F%3Aaiohttp%3Aaiohttp&cpe_version=cpe%3A%2F%3Aaiohttp%3Aaiohttp%3A1.1.0) in `aiohttp` package.